### PR TITLE
Fix error in getting-started code snippets

### DIFF
--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -372,7 +372,7 @@ document.addEventListener('click', ({target}) => {
 
     // since we added a name to the 'davinci-fragment' in our DOM, we can refer
     // directly to functions declared on that fragment.
-    context.fragments.functions.todos.addTodoItem(name)
+    context.fragments.todos.functions.addTodoItem(name)
   }
 })
 ```


### PR DESCRIPTION
This fixes an error in the getting-started code where the order of elements was wrong:

correct order -> context.fragments.fragmentName.functions.functionName

"todos" is the name of the fragment on which the function should be called