### PR TITLE
#32 fix type exports

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.js text eol=lf
+*.ts text eol=lf

--- a/package.json
+++ b/package.json
@@ -33,11 +33,16 @@
   "type": "module",
   "main": "./dist/collage.umd.js",
   "module": "./dist/collage.es.js",
-  "typings": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "import": "./dist/collage.es.js",
-      "require": "./dist/collage.umd.js"
+      "import": {
+        "types":"./dist/index.d.ts",
+        "default": "./dist/collage.es.js"
+      },
+      "require": {
+        "types":"./dist/index.d.ts",
+        "default": "./dist/collage.umd.js"
+      }
     }
   },
   "scripts": {


### PR DESCRIPTION
Please check if this works for all your targeted scenarios. Should be ok for typescript import.
Basically when the never exports key is used the typings/types key seems to be ignored.