### PR TITLE
Tweak line highlighting in getting started guide

### DIFF
--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -206,7 +206,7 @@ Just use the `<collage-fragment>` tag to embed the Todo fragment into the Dashbo
 :::: code-group
 ::: code-group-item dashboard/index.html
 
-```html{16-19}
+```html{17-20}
 <!DOCTYPE html>
 <html>
   <head>
@@ -254,7 +254,7 @@ Here we will need the [**Topics API**](../docs/core-api.html#topics-api) specifi
 :::: code-group
 ::: code-group-item todos/main.js
 
-```javascript{1-11,18-23,34,45}
+```javascript{2-11,18-23,34,45}
 import { expose } from '@collage/core'
 const context = await expose({
   services: {
@@ -344,7 +344,7 @@ In this case we would like to have access to the todos 'active' topic and to the
 :::: code-group
 ::: code-group-item dashboard/main.js
 
-```javascript{1-11,15,23}
+```javascript{1-8,10,14-20,22-30}
 import { expose } from '@collage/core'
 const context = await expose({
   services: {
@@ -380,7 +380,7 @@ document.addEventListener('click', ({target}) => {
 :::
 ::: code-group-item dashboard/index.html
 
-```html{11,12,17,23,28}
+```html{13,18,24,29}
 <!DOCTYPE html>
 <html>
   <head>
@@ -414,9 +414,8 @@ document.addEventListener('click', ({target}) => {
     </main>
     <aside>
       <!--
-        define the todos app as a fragment inside this arrangement and set 
-        the url to a location we can access the fragment.
-        Also give it a name we can reference it.
+        add the todos app as a fragment inside this arrangement and give it
+        a name for identification
       -->
       <collage-fragment
         url="http://localhost:4000/"


### PR DESCRIPTION
Tweaked highlighting of newly added/changed lines in some code snippets of the [getting started guide](https://sickag.github.io/collage/guide/getting-started.html) as it was a bit off sometimes (and adjusted one of the comments to make it consistent throughout all versions of `dashboard/index.html`).

Example before:
<img width="828" alt="Screenshot 2024-04-08 at 19 22 25" src="https://github.com/SICKAG/collage/assets/6704563/213888f6-e5d0-4820-b6ba-eea9bd5e4e87">

Example after:
<img width="822" alt="Screenshot 2024-04-08 at 19 22 44" src="https://github.com/SICKAG/collage/assets/6704563/25bfa99c-7e90-4ce5-93c7-4650f283e43d">
